### PR TITLE
カテゴリーIDに基づいたスレッドの一覧を返すように変更

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -60,7 +60,17 @@ Deno.serve((req) => {
   }
 
   if (req.method === "GET" && url.pathname === "/thread/list") {
-    return new Response(JSON.stringify(threads), {
+    const categoryId = url.searchParams.get("categoryId");
+    if (!categoryId) {
+      return new Response(JSON.stringify({ error: "categoryId is required" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const threadsInCategory = threads.get(Number(categoryId)) ||
+      { threads: [] };
+    return new Response(JSON.stringify(threadsInCategory), {
       status: 200,
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
## 概要
`GET /thread/list`がスレッドの一覧をそのまま返すようになっていたため、クライアントから渡されたカテゴリーIDをもとに、それに紐づいたスレッドの一覧を返すように変更
データなどは一旦仮で定義している

## 関連
https://github.com/kota4976/2026-hackathon-b/issues/18

## テスト方法
- `deno task dev`でサーバーを起動する
- 以下のURLにアクセスして、それぞれレスポンスが返ってくることを確認する
  - http://localhost:8000/thread/list?categoryId=1
  - http://localhost:8000/thread/list?categoryId=2
  - http://localhost:8000/thread/list?categoryId=3
- http://localhost:8000/thread/list?categoryId=4 にアクセスして空のリストが返ってくることを確認する
- http://localhost:8000/thread/list にアクセスして`categoryId is required`のエラーが返ってくることを確認する

## レビュアーチェックリスト

- [ ] 関連にIssueもしくはタスクのリンクがあること