### PR TITLE
スレッドIDをもとにスレッドの内容を返すAPIを実装

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -125,6 +125,44 @@ Deno.serve((req) => {
     });
   }
 
+  if (req.method === "GET" && url.pathname === "/thread/contents") {
+    const threadId = url.searchParams.get("threadId");
+    if (!threadId) {
+      return new Response(JSON.stringify({ error: "threadId is required" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    let threadContent: Thread | null = null;
+    for (const threadsInCategory of threads.values()) {
+      // スレッドIDに一致するスレッドを探す
+      const thread = threadsInCategory.threads.find(
+        (t) => t.threadId === Number(threadId),
+      );
+      if (thread) {
+        threadContent = thread;
+        break;
+      }
+    }
+
+    // スレッドが見つからない場合は404エラー
+    if (!threadContent) {
+      return new Response(JSON.stringify({ error: "Thread not found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(JSON.stringify(threadContent), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
+  }
+
   return serveDir(req, {
     fsRoot: "./public",
     urlRoot: "",


### PR DESCRIPTION
## 概要
スレッドの内容を返す`GET /thread/contents/{threadId}`の実装
動作確認用に返信情報を仮データに追加している

## 関連

https://github.com/kota4976/2026-hackathon-b/issues/6

## テスト方法
- `deno task dev`でサーバーを起動しておく
- http://localhost:8000/thread/contents?threadId=1 にアクセスして返信情報を含むレスポンスが返ることを確認
  - 同じようにthreadId=2 ~ 6も確認
- http://localhost:8000/thread/contents?threadId=7 にアクセスしたとき`Thread not found`のエラーが返ることを確認

## レビュアーチェックリスト

- [ ] 関連にIssueもしくはタスクのリンクがあること